### PR TITLE
4-3　従業員詳細画面から従業員一覧への画面遷移を実装

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -88,7 +88,7 @@ public class AdministratorController {
 		if (result.hasErrors()) {
 			return toInsert(form);
 		}
-
+		session.setAttribute("administratorName", form.getName());
 
 		return "redirect:/";
 	}

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -19,24 +19,17 @@ public class InsertAdministratorForm {
 	/** メールアドレス */
 	private String mailAddress;
 
-	public String getConfirmationPassword() {
-		return confirmationPassword;
-	}
-
-	public void setConfirmationPassword(String confirmationPassword) {
-		this.confirmationPassword = confirmationPassword;
-	}
-
 	@NotBlank(message = "パスワードを入力してください")
 	/** パスワード */
 	private String password;
-	@NotBlank(message = "確認パスワードを入力してください")
-	/** パスワード */
-	private String confirmationPassword;
+
 
 	@NotBlank(message = "確認パスワードを入力してください")
 	/** パスワード */
 	private String confirmationPassword;
+
+
+
 
 	public String getConfirmationPassword() {
 		return confirmationPassword;

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -67,9 +67,9 @@
               </li>
             </ul>
             <p class="navbar-text navbar-right">
-              <span th:text="${session.administratorName + 'さん'}"
+              <span th:text="${session.administratorName}"
               >山田太郎</span
-              >さんこんにちは！ &nbsp;&nbsp;&nbsp;
+              >こんにちは！ &nbsp;&nbsp;&nbsp;
               <a
                 href="../administrator/login.html"
                 class="navbar-link"

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -85,7 +85,7 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li>従業員リスト</li>
+        <li><a th:href="@{/employee/showList}">従業員リスト</a></li>
         <li class="active">従業員詳細</li>
       </ol>
 


### PR DESCRIPTION
改修要望4-3の従業員詳細画面から従業員一覧への画面するリンクが切れていたので変更しました。